### PR TITLE
🐛 Fix: Add missing handover_photo_count field to resolve ParseError

### DIFF
--- a/models/hr_custody.py
+++ b/models/hr_custody.py
@@ -168,6 +168,22 @@ class HrCustody(models.Model):
         store=False
     )
 
+    # ✅ FIX: Add missing handover_photo_count field
+    handover_photo_count = fields.Integer(
+        string='Handover Photo Count',
+        compute='_compute_handover_photo_count',
+        store=False,
+        help='Count of handover photos for this custody'
+    )
+
+    # Add return photo count for consistency
+    return_photo_count = fields.Integer(
+        string='Return Photo Count',
+        compute='_compute_return_photo_count',
+        store=False,
+        help='Count of return photos for this custody'
+    )
+
     # 🔧 COMPUTED METHODS FOR PHOTO MANAGEMENT
 
     @api.depends('return_type', 'return_date', 'expected_return_period', 'state', 'actual_return_date')
@@ -206,6 +222,18 @@ class HrCustody(models.Model):
                 record.photo_counts = ", ".join(count_list)
             else:
                 record.photo_counts = "No photos"
+
+    @api.depends('handover_photo_ids')
+    def _compute_handover_photo_count(self):
+        """Compute count of handover photos"""
+        for record in self:
+            record.handover_photo_count = len(record.handover_photo_ids)
+
+    @api.depends('return_photo_ids')
+    def _compute_return_photo_count(self):
+        """Compute count of return photos"""
+        for record in self:
+            record.return_photo_count = len(record.return_photo_ids)
 
     @api.depends('attachment_ids', 'state')
     def _compute_photo_status(self):


### PR DESCRIPTION
## 🐛 Bug Fix: Field Reference Error

### Problem
The Odoo application was failing to load with this error:
```
Field "handover_photo_count" does not exist in model "hr.custody"
```

### Root Cause
- The XML view `hr_custody_views_complete.xml` was referencing a field `handover_photo_count` at line 55
- This field was not defined in the `hr.custody` model
- This caused a ParseError during module loading

### Solution
✅ **Added missing computed fields to the model:**

1. **`handover_photo_count`** - Integer field that computes the count of handover photos
2. **`return_photo_count`** - Integer field that computes the count of return photos (added for consistency)

### Technical Details
- Both fields use `@api.depends()` decorators for proper dependency tracking
- Fields are computed from their respective One2many relationships
- Fields are marked as `store=False` since they're computed fields
- Added proper help text for documentation

### Files Changed
- `models/hr_custody.py` - Added the missing computed fields

### Testing
- The module should now load without ParseError
- Photo counts will be properly calculated and displayed in views
- Both handover and return photo counts are now available for use in views

### Impact
- ✅ Fixes the module loading error
- ✅ Enables photo count functionality in views
- ✅ Maintains backward compatibility
- ✅ No database migration required (computed fields)