### PR TITLE
🐛 Fix: Add missing total_photo_count field to complete ParseError resolution

### DIFF
--- a/models/hr_custody.py
+++ b/models/hr_custody.py
@@ -168,7 +168,7 @@ class HrCustody(models.Model):
         store=False
     )
 
-    # ✅ FIX: Add missing handover_photo_count field
+    # ✅ FIX: Add missing photo count fields
     handover_photo_count = fields.Integer(
         string='Handover Photo Count',
         compute='_compute_handover_photo_count',
@@ -176,12 +176,19 @@ class HrCustody(models.Model):
         help='Count of handover photos for this custody'
     )
 
-    # Add return photo count for consistency
     return_photo_count = fields.Integer(
         string='Return Photo Count',
         compute='_compute_return_photo_count',
         store=False,
         help='Count of return photos for this custody'
+    )
+
+    # ✅ FIX: Add missing total_photo_count field
+    total_photo_count = fields.Integer(
+        string='Total Photo Count',
+        compute='_compute_total_photo_count',
+        store=False,
+        help='Total count of all photos for this custody'
     )
 
     # 🔧 COMPUTED METHODS FOR PHOTO MANAGEMENT
@@ -234,6 +241,16 @@ class HrCustody(models.Model):
         """Compute count of return photos"""
         for record in self:
             record.return_photo_count = len(record.return_photo_ids)
+
+    @api.depends('attachment_ids')
+    def _compute_total_photo_count(self):
+        """Compute total count of all photos"""
+        for record in self:
+            # Count only image attachments for this custody
+            image_attachments = record.attachment_ids.filtered(
+                lambda a: a.mimetype and a.mimetype.startswith('image/')
+            )
+            record.total_photo_count = len(image_attachments)
 
     @api.depends('attachment_ids', 'state')
     def _compute_photo_status(self):


### PR DESCRIPTION
## 🐛 Bug Fix: Missing total_photo_count Field

### Problem
After fixing the previous `handover_photo_count` issue, another ParseError occurred:
```
Field "total_photo_count" does not exist in model "hr.custody"
```

### Root Cause
- The XML view references `total_photo_count` at line 195
- This field was not defined in the `hr.custody` model
- This caused a second ParseError during module loading

### Solution
✅ **Added missing `total_photo_count` computed field:**

- **`total_photo_count`** - Integer field that computes the total count of all image attachments
- Uses `@api.depends('attachment_ids')` for proper dependency tracking
- Filters only image attachments using `mimetype.startswith('image/')`
- Provides accurate count for UI display

### Technical Details
- Field is computed from the `attachment_ids` relationship
- Only counts actual image files (not other attachments)
- Marked as `store=False` since it's a computed field
- Added proper help text for documentation

### Files Changed
- `models/hr_custody.py` - Added the missing `total_photo_count` computed field

### Testing
- The module should now load completely without ParseError
- Total photo count will be properly calculated and displayed in views
- Complements the existing `handover_photo_count` and `return_photo_count` fields

### Impact
- ✅ Resolves the second ParseError completely
- ✅ Enables total photo count functionality in views
- ✅ Maintains consistency with other photo count fields
- ✅ No database migration required (computed field)

This completes the photo count field requirements and should fully resolve the module loading issues.