### PR TITLE
🔧 Hotfix: Add method compatibility layer for view calls

### DIFF
--- a/models/hr_custody.py
+++ b/models/hr_custody.py
@@ -531,7 +531,27 @@ class HrCustody(models.Model):
                 raise UserError(_('You cannot delete approved or returned custody records'))
         return super().unlink()
 
-    # 🎯 WORKFLOW METHODS - Enhanced
+    # 🎯 WORKFLOW METHODS - Enhanced & Backward Compatible
+
+    def sent(self) -> None:
+        """Legacy method name for backward compatibility with views"""
+        return self.action_send_for_approval()
+
+    def approve(self) -> None:
+        """Legacy method name for backward compatibility with views"""
+        return self.action_approve()
+
+    def refuse_with_reason(self) -> Dict[str, Any]:
+        """Legacy method name for backward compatibility with views"""
+        return self.action_refuse_with_reason()
+
+    def set_to_draft(self) -> None:
+        """Legacy method name for backward compatibility with views"""
+        return self.action_set_to_draft()
+
+    def set_to_return(self) -> None:
+        """Legacy method name for backward compatibility with views"""
+        return self.action_return_equipment()
 
     def action_send_for_approval(self) -> None:
         """Send custody request for approval"""


### PR DESCRIPTION
## 🔧 Quick Fix: Method Name Compatibility

### Problem
After the Odoo 18 compliance update, the module failed to load with error:
```
sent is not a valid action on hr.custody
```

### Root Cause
- The views still reference legacy method names (`sent`, `approve`, etc.)
- The compliance update renamed methods to more structured names
- This created a mismatch between view calls and model methods

### Solution
✅ **Added legacy method wrapper for backward compatibility:**

```python
# Legacy method names for view compatibility
def sent(self) -> None:
    """Legacy method name for backward compatibility with views"""
    return self.action_send_for_approval()

def approve(self) -> None:
    """Legacy method name for backward compatibility with views"""
    return self.action_approve()

# ... and so on for all workflow methods
```

### Technical Approach
- ✅ **Maintains new structured method names** for better code organization
- ✅ **Adds legacy wrappers** that call the new implementation methods
- ✅ **Zero breaking changes** - all existing views continue to work
- ✅ **Future-ready** - new code can use structured method names

### Methods Fixed
| Legacy Method | New Method | Status |
|---------------|------------|---------|
| `sent` | `action_send_for_approval` | ✅ Fixed |
| `approve` | `action_approve` | ✅ Fixed |
| `refuse_with_reason` | `action_refuse_with_reason` | ✅ Fixed |
| `set_to_draft` | `action_set_to_draft` | ✅ Fixed |
| `set_to_return` | `action_return_equipment` | ✅ Fixed |

### Impact
- 🔧 **Immediate Fix**: Module loads successfully without errors
- 🔄 **Backward Compatible**: All existing views work without modification
- 📈 **Future Ready**: New code can use improved method names
- 🛡️ **Safe**: No functional changes, only compatibility layer

This is a critical hotfix that resolves the module loading issue while preserving all the Odoo 18 compliance improvements.